### PR TITLE
Updated GroupAction toBridgeObject to enable recalling scenes

### DIFF
--- a/lib/src/group/group_action.dart
+++ b/lib/src/group/group_action.dart
@@ -101,6 +101,9 @@ abstract class GroupAction
     if (colorMode != null) {
       body['colormode'] = colorMode;
     }
+    if (scene != null) {
+      body['scene'] = scene;
+    }
     return body;
   }
 }


### PR DESCRIPTION
Was playing around and realized that the scene parameter for GroupAction was not being serialized. This update enables it to be serialized and send scene recall commands.